### PR TITLE
Fixed a bug in xmlpoke task causing additional whitespace and newline character when poke empty value into element #61

### DIFF
--- a/src/NAnt.Core/Tasks/XmlPokeTask.cs
+++ b/src/NAnt.Core/Tasks/XmlPokeTask.cs
@@ -186,7 +186,7 @@ namespace NAnt.Core.Tasks {
                 // file if no nodes were found in the first place.
                 if (nodes.Count > 0) {
                     UpdateNodes(nodes, Value);
-                    SaveDocument(document, XmlFile.FullName);
+                    SaveDocument(document, XmlFile.FullName, !PreserveWhitespace);
                 } 
             } catch (BuildException ex) {
                 throw ex;
@@ -306,13 +306,16 @@ namespace NAnt.Core.Tasks {
         /// </summary>
         /// <param name="document">The XML document to be saved.</param>
         /// <param name="fileName">The file name to save the XML document under.</param>
-        private void SaveDocument(XmlDocument document, string fileName) {
+        /// <param name="indent">
+        /// Value for <see cref="XmlWriterSettings.Indent"/> that is set before the xml is saved.
+        /// </param>
+        private void SaveDocument(XmlDocument document, string fileName, bool indent) {
             try {
                 Log(Level.Verbose, "Attempting to save XML document" 
                     + " to '{0}'.", fileName);
 
                 XmlWriterSettings wSettings = new XmlWriterSettings();
-                wSettings.Indent = true;
+                wSettings.Indent = indent;
                 wSettings.ConformanceLevel = ConformanceLevel.Fragment;
                 using (XmlWriter output = XmlWriter.Create(fileName, wSettings))
                 {


### PR DESCRIPTION
Contains [upstream PR 52](https://github.com/nant/nant/pull/52)